### PR TITLE
Volunteer CRUD

### DIFF
--- a/Pages/AddVolunteer.razor
+++ b/Pages/AddVolunteer.razor
@@ -1,0 +1,38 @@
+﻿@page "/addvolunteer"
+@using Karma.Models
+@using Karma.Data
+@inject IJSRuntime m_jsRuntime
+
+<h1>Add volunteer</h1>
+
+@if (m_httpContextAccessor.HttpContext.User.Identity.IsAuthenticated)
+{
+    <label for="fname">Volunteer name:</label>
+    <input type="text" @bind="@VolunteerName" @oninput="@((e) => { VolunteerName = (string)e.Value; })" />
+    <br>
+    <br>
+    <label for="fname">Volunteer surname:</label>
+    <input type="text" @bind="@VolunteerSurname" @oninput="@((e) => { VolunteerSurname = (string)e.Value; })" />
+    <br>
+    <br>
+    <button class="btn btn-primary" @onclick="AddThisVolunteer">Add volunteer</button>
+}
+else
+{
+    <label for="fname">Please LogIn:</label>
+}
+@code
+{
+    KarmaContext KarmaContext = new KarmaContext();
+    string VolunteerName { get; set; }
+    string VolunteerSurname { get; set; }
+
+    private async Task AddThisVolunteer()
+    {
+        var vol = new Volunteer(VolunteerName, VolunteerSurname, Guid.NewGuid());
+        KarmaContext.Volunteers.Add(vol);
+        KarmaContext.SaveChanges();
+        m_uriHelper.NavigateTo("/volunteers");
+        await m_jsRuntime.InvokeVoidAsync("alert", "The volunteer has been added");
+    }
+}

--- a/Pages/AddVolunteer.razor
+++ b/Pages/AddVolunteer.razor
@@ -29,7 +29,7 @@ else
 
     private async Task AddThisVolunteer()
     {
-        var vol = new Volunteer(VolunteerName, VolunteerSurname, Guid.NewGuid());
+        var vol = new Volunteer(name: VolunteerName, surname: VolunteerSurname, Guid.NewGuid());
         KarmaContext.Volunteers.Add(vol);
         KarmaContext.SaveChanges();
         m_uriHelper.NavigateTo("/volunteers");

--- a/Pages/EditCharityEvent.razor
+++ b/Pages/EditCharityEvent.razor
@@ -101,10 +101,12 @@
     private void AddVolunteerToEvent(Guid id)
     {
         CharityEvent.Volunteers.Add(KarmaContext.Volunteers.Where(p => p.Id == id).FirstOrDefault());
+        KarmaContext.SaveChanges();
     }
 
     private void RemoveVolunteerFromEvent(Guid id)
     {
         CharityEvent.Volunteers.Remove(KarmaContext.Volunteers.Where(p => p.Id == id).FirstOrDefault());
+        KarmaContext.SaveChanges();
     }
 }

--- a/Pages/EditCharityEvent.razor
+++ b/Pages/EditCharityEvent.razor
@@ -3,6 +3,7 @@
 @using Karma.Data
 @using Z.EntityFramework.Plus;
 @inject IJSRuntime m_jsRuntime
+@using Microsoft.EntityFrameworkCore;
 
 @if (m_httpContextAccessor.HttpContext.User.Identity.IsAuthenticated)
 {
@@ -14,6 +15,45 @@
     <br>
     <label for="fname">Event description:</label>
     <input type="text" @bind="@CharityEvent.Description" @oninput="@((e) => { CharityEvent.Description = (string)e.Value; })" />
+    <br>
+    <br>
+    <tbody>
+        <tr>
+            <th>Volunteers that are working on this event</th>
+        </tr>
+        <tr>
+            @foreach (var volunteer in GetVolunteersInThisEvent())
+            {
+                <li>
+                    @volunteer.Name
+                    @volunteer.Surname
+                    <div align="left">
+                        <button class="btn btn-primary" @onclick="() => RemoveVolunteerFromEvent(volunteer.Id)">Remove</button>
+                    </div>
+                </li>
+            }
+        </tr>
+    </tbody>
+    <br>
+    <br>
+    <tbody>
+        <tr>
+            <th>Volunteers that could be added to this event</th>
+            <th></th>
+        </tr>
+        <tr>
+            @foreach (var volunteer in GetVolunteersNotInThisEvent())
+            {
+                <li>
+                    @volunteer.Name
+                    @volunteer.Surname
+                    <div align="left">
+                        <button class="btn btn-primary" @onclick="() => AddVolunteerToEvent(volunteer.Id)">Add</button>
+                    </div>
+                </li>
+            }
+        </tr>
+    </tbody>
     <br>
     <br>
     <button class="btn btn-primary" @onclick="UpdateEvent">Update event</button>
@@ -45,6 +85,26 @@
 
     protected override void OnInitialized()
     {
-        CharityEvent = KarmaContext.Events.Where(p => p.Id == Id).FirstOrDefault();
+        CharityEvent = KarmaContext.Events.Include(p => p.Volunteers).Where(p => p.Id == Id).FirstOrDefault();
+    }
+
+    public IEnumerable<IVolunteer> GetVolunteersInThisEvent()
+    {
+        return KarmaContext.Events.Include(p => p.Volunteers).Where(p => p.Id == Id).Select(p => p.Volunteers).SelectMany(p => p);
+    }
+
+    public IEnumerable<IVolunteer> GetVolunteersNotInThisEvent()
+    {
+        return KarmaContext.Volunteers.Include(p => p.Events).Where(p => !p.Events.Contains(CharityEvent));
+    }
+
+    private void AddVolunteerToEvent(Guid id)
+    {
+        CharityEvent.Volunteers.Add(KarmaContext.Volunteers.Where(p => p.Id == id).FirstOrDefault());
+    }
+
+    private void RemoveVolunteerFromEvent(Guid id)
+    {
+        CharityEvent.Volunteers.Remove(KarmaContext.Volunteers.Where(p => p.Id == id).FirstOrDefault());
     }
 }

--- a/Pages/ManageIndividualVolunteer.razor
+++ b/Pages/ManageIndividualVolunteer.razor
@@ -14,7 +14,7 @@
         <input type="text" @bind="@volunteer.Name" @oninput="@((e) => { volunteer.Name = (string)e.Value; })" />
         <br>
         <br>
-        <label for="fname">Volunterr surname:</label>
+        <label for="fname">Volunteer surname:</label>
         <input type="text" @bind="@volunteer.Surname" @oninput="@((e) => { volunteer.Surname = (string)e.Value; })" />
         <br>
         <br>
@@ -69,38 +69,40 @@ else
     [Parameter]
     public Guid Id { get; set; }
     private Volunteer volunteer;
-    KarmaContext karmaContext = new KarmaContext();
+    KarmaContext m_context = new KarmaContext();
 
     private async Task UpdateVolunteerData()
     {
-        karmaContext.Volunteers.Update(volunteer);
-        karmaContext.SaveChanges();
+        m_context.Volunteers.Update(volunteer);
+        m_context.SaveChanges();
         m_uriHelper.NavigateTo("/volunteers");
         await m_jsRuntime.InvokeVoidAsync("alert", "The volunteer data has been updated");
     }
 
     protected override void OnInitialized()
     {
-        volunteer = karmaContext.Volunteers.Include(p => p.Events).Where(p => p.Id == Id).FirstOrDefault();
+        volunteer = m_context.Volunteers.Include(p => p.Events).Where(p => p.Id == Id).FirstOrDefault();
     }
 
     public IEnumerable<ICharityEvent> GetEventsOfThisVolunteer()
     {
-        return karmaContext.Volunteers.Include(p => p.Events).Where(p => p.Id == Id).Select(p => p.Events).SelectMany(p => p);
+        return m_context.Volunteers.Include(p => p.Events).Where(p => p.Id == Id).Select(p => p.Events).SelectMany(p => p);
     }
 
     public IEnumerable<ICharityEvent> GetEventsNotOfThisVolunteer()
     {
-        return karmaContext.Events.Include(p => p.Volunteers).Where(p => !p.Volunteers.Contains(volunteer));
+        return m_context.Events.Include(p => p.Volunteers).Where(p => !p.Volunteers.Contains(volunteer));
     }
 
     private void AddEventToVolunteerList(Guid id)
     {
-        volunteer.Events.Add(karmaContext.Events.Where(p => p.Id == id).FirstOrDefault());
+        volunteer.Events.Add(m_context.Events.Where(p => p.Id == id).FirstOrDefault());
+        m_context.SaveChanges();
     }
 
     private void RemoveEventFromList(Guid id)
     {
-        volunteer.Events.Remove(karmaContext.Events.Where(p => p.Id == id).FirstOrDefault());
+        volunteer.Events.Remove(m_context.Events.Where(p => p.Id == id).FirstOrDefault());
+        m_context.SaveChanges();
     }
 }

--- a/Pages/ManageIndividualVolunteer.razor
+++ b/Pages/ManageIndividualVolunteer.razor
@@ -1,0 +1,106 @@
+﻿@page "/volunteer/{Id:guid}"
+@using System.Linq
+@using Karma.Models
+@inject IJSRuntime m_jsRuntime
+@using Microsoft.EntityFrameworkCore;
+
+@if (m_httpContextAccessor.HttpContext.User.Identity.IsAuthenticated)
+{
+    @if (volunteer != null)
+    {
+        <h1>Manage volunteer</h1>
+
+        <label for="fname">Volunteer name:</label>
+        <input type="text" @bind="@volunteer.Name" @oninput="@((e) => { volunteer.Name = (string)e.Value; })" />
+        <br>
+        <br>
+        <label for="fname">Volunterr surname:</label>
+        <input type="text" @bind="@volunteer.Surname" @oninput="@((e) => { volunteer.Surname = (string)e.Value; })" />
+        <br>
+        <br>
+        <br>
+        <br>
+        <table class="table">
+            <tbody>
+                <tr>
+                    <th>Charity events that this volunteer is working on:</th>
+                    <th>Actions:</th>
+                </tr>
+                @foreach (var charityEvent in GetEventsOfThisVolunteer())
+                {
+                    <tr>
+                        <td>@charityEvent.Name</td>
+                        <td>
+                            <button class="btn btn-primary" @onclick="() => RemoveEventFromList(charityEvent.Id)">Remove</button>
+                        </td>
+                    </tr>
+                }
+                <tr>
+                    <th>Charity events that this volunteer could be a part of:</th>
+                    <th>Actions:</th>
+                </tr>
+                @foreach (var charityEvent in GetEventsNotOfThisVolunteer())
+                {
+                    <tr>
+                        <td>@charityEvent.Name</td>
+                        <td>
+                            <button class="btn btn-primary" @onclick="() => AddEventToVolunteerList(charityEvent.Id)">Add</button>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+        <br>
+        <br>
+        <button class="btn btn-primary" @onclick="UpdateVolunteerData">Update volunteer data</button>
+    }
+    else
+    {
+        <h1>Sorry,but this volunteer was not found</h1>
+    }
+}
+else
+{
+    <label for="fname">Please LogIn</label>
+}
+
+@code
+{
+    [Parameter]
+    public Guid Id { get; set; }
+    private Volunteer volunteer;
+    KarmaContext karmaContext = new KarmaContext();
+
+    private async Task UpdateVolunteerData()
+    {
+        karmaContext.Volunteers.Update(volunteer);
+        karmaContext.SaveChanges();
+        m_uriHelper.NavigateTo("/volunteers");
+        await m_jsRuntime.InvokeVoidAsync("alert", "The volunteer data has been updated");
+    }
+
+    protected override void OnInitialized()
+    {
+        volunteer = karmaContext.Volunteers.Include(p => p.Events).Where(p => p.Id == Id).FirstOrDefault();
+    }
+
+    public IEnumerable<ICharityEvent> GetEventsOfThisVolunteer()
+    {
+        return karmaContext.Volunteers.Include(p => p.Events).Where(p => p.Id == Id).Select(p => p.Events).SelectMany(p => p);
+    }
+
+    public IEnumerable<ICharityEvent> GetEventsNotOfThisVolunteer()
+    {
+        return karmaContext.Events.Include(p => p.Volunteers).Where(p => !p.Volunteers.Contains(volunteer));
+    }
+
+    private void AddEventToVolunteerList(Guid id)
+    {
+        volunteer.Events.Add(karmaContext.Events.Where(p => p.Id == id).FirstOrDefault());
+    }
+
+    private void RemoveEventFromList(Guid id)
+    {
+        volunteer.Events.Remove(karmaContext.Events.Where(p => p.Id == id).FirstOrDefault());
+    }
+}

--- a/Pages/Volunteers.razor
+++ b/Pages/Volunteers.razor
@@ -66,7 +66,7 @@ else
 
     public void NavigateToAddVolunteer()
     {
-        m_uriHelper.NavigateTo($"addvolunteer");
+        m_uriHelper.NavigateTo("addvolunteer");
     }
 
     private async Task RemoveVolunteer(Guid id)

--- a/Pages/Volunteers.razor
+++ b/Pages/Volunteers.razor
@@ -2,18 +2,22 @@
 @using Karma.Models
 @using Microsoft.EntityFrameworkCore;
 @using System.Linq;
+@inject IJSRuntime m_jsRuntime
 <h1>Volunteers</h1>
-
-<p>Here you can find the list of volunteers working on various projects.</p>
 
 @if (m_httpContextAccessor.HttpContext.User.Identity.IsAuthenticated)
 {
+    <p>
+        Here you can find the list of volunteers working on various projects.
+        <button class="btn btn-primary" @onclick="NavigateToAddVolunteer">Add a new volunteer</button>
+    </p>
     <table class="table">
         <tbody>
             <tr>
                 <th>Name</th>
                 <th>Surname</th>
                 <th>Events</th>
+                <th>Actions</th>
             </tr>
             @foreach (var volunteer in GetVolunteers())
             {
@@ -32,6 +36,10 @@
                             }
                         }
 
+                    </td>
+                    <td>
+                        <button class="btn btn-primary" @onclick="() => NavigateToManageVolunteer(volunteer.Id)">Manage volunteer</button>
+                        <button class="btn btn-primary" style ="background-color: black;" @onclick="() => RemoveVolunteer(volunteer.Id)">Remove the volunteer</button>
                     </td>
                 </tr>
             }
@@ -54,5 +62,23 @@ else
     public void NavigateToIndividualEvent(Guid id)
     {
         m_uriHelper.NavigateTo($"event/{id}");
+    }
+
+    public void NavigateToAddVolunteer()
+    {
+        m_uriHelper.NavigateTo($"addvolunteer");
+    }
+
+    private async Task RemoveVolunteer(Guid id)
+    {
+        KarmaContext.Volunteers.Where(x => x.Id == id).DeleteFromQuery();
+        KarmaContext.SaveChanges();
+        m_uriHelper.NavigateTo("/volunteers");
+        await m_jsRuntime.InvokeVoidAsync("alert", "The event has been deleted");
+    }
+
+    public void NavigateToManageVolunteer(Guid id)
+    {
+        m_uriHelper.NavigateTo($"volunteer/{id}");
     }
 }


### PR DESCRIPTION
Added a way to create new volunteers. Added a way to edit volunteer data and remove or assign them to projects. Added a way to delete volunteer data. Modified charity event editing page so that it would be easier to assign or remove volunteers to or from events.

Updated volunteer page:
![image](https://user-images.githubusercontent.com/76516162/136096316-03ab0eca-7d80-4108-a57b-0675c3723ec7.png)

New volunteer management page:
![image](https://user-images.githubusercontent.com/76516162/136096431-01b2d3c7-c84b-4b35-9793-ba5b246783a0.png)

Updated charity event editing page:
![image](https://user-images.githubusercontent.com/76516162/136096548-72cfe7bb-a2d7-411d-96c4-8aaf48a0f2d7.png)
